### PR TITLE
docs: formalize DomI upstream contract in CLAUDE.md and constitution

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -83,7 +83,7 @@ Edge2Elem: ndarray[n_edges, 2]        # Edge adjacent elements (-1 if boundary)
 
 ### Before Starting Work
 1. Read `PLANNING_DATA_STRUCTURE_MODERNIZATION.md` for context
-2. All pertinent skills should be pulled from https://github.com/domattioli/DomI and gitignored for this repo. 
+2. Skills are pulled from `domattioli/DomI` per the [DomI Sync Contract](#domi-sync-contract). The startup hook (`scripts/instructions_on_start.sh`) hard-stops on drift; run `/sync-from-domi` to unblock.
 3. Check the GitHub issue for task details
 4. Run `pytest -v` locally to verify baseline
 5. Review related code sections (adjacency building, skeletonization)
@@ -342,9 +342,21 @@ claude plugin install introspect@DomI           # required (end-of-session retro
 claude plugin install request-from-domi@DomI    # opt-in (file/vote on skill requests)
 ```
 
+### Routine session instructions
+
+Every scheduled Claude Code routine targeting CHILmesh uses **this exact session prompt** (paste into the routine config as the session instruction line):
+
+```
+Read https://raw.githubusercontent.com/domattioli/DomI/main/claude_routine_instructions.md then .planning/constitution.md → .planning/project_plan.md → .claude/CLAUDE.md.
+```
+
+Read order is precedence order: DomI universal defaults are loaded first, then CHILmesh-specific rules layer on top. CHILmesh's `.planning/constitution.md` and `.claude/CLAUDE.md` override DomI defaults wherever they conflict.
+
 ---
 
 ## Skills
+
+> **Source of truth:** `github-release` and `pypi-publish` are pulled from `domattioli/DomI` via the `sync-from-domi` skill (see [DomI Sync Contract](#domi-sync-contract)). **Do not maintain local copies** — they live upstream and are kept current via session-start drift checks. The notes below describe surface (triggers, prerequisites) for convenience only; canonical SKILL.md files live in DomI.
 
 ### Skill: github-release
 

--- a/.planning/constitution.md
+++ b/.planning/constitution.md
@@ -415,6 +415,21 @@ Changes can be reverted if:
 
 ---
 
+## External Upstream: DomI
+
+`domattioli/DomI` manages foundational skills and policy used by this repo.
+`.domi-pin` is committed; session start auto-checks drift via
+`scripts/instructions_on_start.sh`. Hard stop on drift; `/sync-from-domi`
+unblocks.
+
+CHILmesh-specific rules (branch policy, API stability) take precedence over
+DomI universal defaults where they conflict. This precedence flows from the
+session-start read order: `.planning/constitution.md` is read before
+`.claude/CLAUDE.md`, and both override DomI universal defaults pulled from
+`https://raw.githubusercontent.com/domattioli/DomI/main/claude_routine_instructions.md`.
+
+---
+
 ## Appendix A: Principles in Action
 
 ### Example 1: Fixing Bug in Skeletonization


### PR DESCRIPTION
## Summary

Follow-up to #82. Formalizes the DomI upstream relationship across both CLAUDE.md and the constitution, replacing one-line informal references with the structured contract language.

### Changes

**`.claude/CLAUDE.md`**
- Replaced the informal *"All pertinent skills should be pulled from https://github.com/domattioli/DomI and gitignored for this repo"* line with a pointer to the formal `## DomI Sync Contract` section + a note that `/sync-from-domi` unblocks drift hard-stops.
- Added a Skills-section preamble noting `github-release` and `pypi-publish` come from DomI via `sync-from-domi` — **do not maintain local copies**. Canonical SKILL.md files live upstream.
- Added a `### Routine session instructions` subsection with the canonical one-liner that scheduled routines paste into their config:
  ```
  Read https://raw.githubusercontent.com/domattioli/DomI/main/claude_routine_instructions.md then .planning/constitution.md → .planning/project_plan.md → .claude/CLAUDE.md.
  ```
- Branch policy (daily-issue-fixing) preserved unchanged.

**`.planning/constitution.md`**
- Added `## External Upstream: DomI` section after section 10 (Document Control), before Appendix A. Records that DomI manages foundational skills/policy, `.domi-pin` is committed and auto-checked at session start, hard stop on drift, and **CHILmesh-specific rules (branch policy, API stability) take precedence over DomI universal defaults where they conflict**.

## Test plan

- [ ] Confirm `grep -n "All pertinent skills should be pulled" .claude/CLAUDE.md` returns nothing.
- [ ] Confirm the routine session instructions one-liner is verbatim copy-pasteable.
- [ ] Confirm `.planning/constitution.md` renders the new section between Document Control and Appendix A.


---
_Generated by [Claude Code](https://claude.ai/code/session_01LQ5jzXejGGxq69EwWRjJ2G)_