### PR TITLE
chore: wire DomI sync contract

### DIFF
--- a/.planning/constitution.md
+++ b/.planning/constitution.md
@@ -1,7 +1,7 @@
 # CHILmesh Governing Constitution
 
 **Effective Date:** 2026-04-26
-**Version:** 1.0
+**Version:** 1.1
 **Scope:** Development governance, decision-making, and evolution principles
 
 ---
@@ -412,21 +412,21 @@ Changes can be reverted if:
 | Version | Date | Author | Changes |
 |---------|------|--------|---------|
 | 1.0 | 2026-04-26 | Dominik Mattioli | Initial constitution (Planning Phase) |
+| 1.1 | 2026-05-08 | Claude (DomI downstream rollout) | Added section 11: External Upstream (DomI). Formalized DomI sync contract governance. |
 
 ---
 
-## External Upstream: DomI
+## 11. EXTERNAL UPSTREAM (DOMI)
 
-`domattioli/DomI` manages foundational skills and policy used by this repo.
-`.domi-pin` is committed; session start auto-checks drift via
-`scripts/instructions_on_start.sh`. Hard stop on drift; `/sync-from-domi`
-unblocks.
+Foundational skills and policy governed by [domattioli/DomI](https://github.com/domattioli/DomI).
 
-CHILmesh-specific rules (branch policy, API stability) take precedence over
-DomI universal defaults where they conflict. This precedence flows from the
-session-start read order: `.planning/constitution.md` is read before
-`.claude/CLAUDE.md`, and both override DomI universal defaults pulled from
-`https://raw.githubusercontent.com/domattioli/DomI/main/claude_routine_instructions.md`.
+1. `.domi-pin` ledger MUST be committed and current.
+2. Session start auto-checks drift via `scripts/instructions_on_start.sh`. Hard stop on drift; `/sync-from-domi` unblocks.
+3. Skills from DomI take precedence over inline implementations. Local repo-specific skills (those NOT shipped by DomI) are exempt.
+4. Repo-specific principles in this constitution override DomI universal defaults where they conflict.
+5. This section does NOT affect existing repo-specific algorithmic principles.
+
+CHILmesh-specific rules (branch policy `daily-issue-fixing`, API stability guarantees) take precedence over DomI universal defaults where they conflict. This precedence flows from the session-start read order: `.planning/constitution.md` is read before `.claude/CLAUDE.md`, and both override DomI universal defaults pulled from `https://raw.githubusercontent.com/domattioli/DomI/main/claude_routine_instructions.md`.
 
 ---
 


### PR DESCRIPTION
Wires this repo to the DomI plugin marketplace contract.

Upstream: domattioli/DomI@88527c5 (PR #24)

Changes:
- Replaces informal DomI reference in `.claude/CLAUDE.md` with formal Block B (`## DomI Sync Contract`)
- Formalizes `## 11. EXTERNAL UPSTREAM (DOMI)` in `.planning/constitution.md` (was unnumbered); bumps version 1.0 → 1.1; adds document-control row
- Adds `scripts/instructions_on_start.sh` with DomI drift-check hook

Note: This PR was pushed to the harness branch `claude/elegant-cerf-KRZbu`. CHILmesh's CLAUDE.md mandates feature work on `daily-issue-fixing`; you may retarget the base to `daily-issue-fixing` if preferred, but this is a one-shot chore commit so `main` is also reasonable.

Manual one-time steps the user must run after merge:
1. `claude plugin marketplace add domattioli/DomI`
2. `claude plugin install sync-from-domi@DomI request-from-domi@DomI introspect@DomI`
3. `bash ~/.claude/plugins/cache/DomI/sync-from-domi/*/skills/sync-from-domi/scripts/update_pin.sh`
4. `git add .domi-pin && git commit -m "chore: init DomI pin"`

---
_Generated by [Claude Code](https://claude.ai/code/session_01DnzRpRUhE2XGnjJuefBiiY)_