### PR TITLE
chore: add attention-request issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/attention-request.md
+++ b/.github/ISSUE_TEMPLATE/attention-request.md
@@ -2,7 +2,7 @@
 name: Owner attention request
 about: Flag an issue as needing the owner's input, decision, or review
 title: ""
-labels: "owner: input-needed"
+labels: "Executive: Needs-Input"
 ---
 
 <!--

--- a/.github/ISSUE_TEMPLATE/attention-request.md
+++ b/.github/ISSUE_TEMPLATE/attention-request.md
@@ -1,0 +1,23 @@
+---
+name: Owner attention request
+about: Flag an issue as needing the owner's input, decision, or review
+title: ""
+labels: "owner: input-needed"
+---
+
+<!--
+Use this template when you need @domattioli to act before work can continue.
+Fill in the block below — the daily digest searches for it.
+-->
+
+<!-- attention-request
+reason: decision | review | unblock | triage   ← delete all but one
+urgency: critical | high | normal               ← delete all but one
+context: replace this with one sentence on what the owner needs to decide or do
+-->
+
+## What's needed
+
+## Options / context
+
+## Related


### PR DESCRIPTION
Adds `.github/ISSUE_TEMPLATE/attention-request.md` — a structured template for flagging issues that need owner input, keyed by the `<!-- attention-request -->` body block used by the daily digest routine.

See DomI#164 for the full convention spec.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MW5KfPnTuQXmMmDeVsqyyV)_