### PR TITLE
fix: secret-guard regex + onstart hard-reset removal + dist excludes (recreated development → main)

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -33,6 +33,7 @@ prune src/chilmesh_cpp/build_local
 prune src/chilmesh_cpp/build
 exclude .domi-pin
 exclude .gitignore
+exclude AGENTS.md
 
 # README image assets must be re-included after `prune output`
 include output/annulus_quickstart.png

--- a/scripts/hooks/secret_path_guard.sh
+++ b/scripts/hooks/secret_path_guard.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # PreToolUse:Write|Edit hook — blocks writes to secret-bearing paths.
-# Synced from DomI upstream. See domattioli/DomI scripts/hooks/secret_path_guard.sh.
+# Pattern synced from DomI canonical copy 2026-06-12 (fixed .env + root-relative bypass).
 
 set -uo pipefail
 
@@ -8,14 +8,19 @@ input="$(cat)"
 path="$(echo "$input" | jq -r '.tool_input.file_path // ""' 2>/dev/null)"
 [ -z "$path" ] && exit 0
 
+# Exemptions — return 0 fast
 case "$path" in
   *.env.example|*.env.template|*.env.test|*.env.sample) exit 0 ;;
   *token-rotation*|*REFRESH_TOKEN_DOCS*|*token_rotation*) exit 0 ;;
   *secret-example*|*credentials.example*) exit 0 ;;
 esac
 
-if echo "$path" | grep -qE '(^|/)\..env$|\.pem$|/credentials\.|/secrets?(\.|$)|/token(\.|$)|\.gpg$|id_rsa$|id_ed25519$'; then
-  echo "BLOCKED (secret_path_guard): $path matches secret-bearing pattern. Rename to *.example or *.template variant." >&2
+# Block paths matching secret patterns.
+# `.env` matches both top-level `.env` and nested `*/foo.env` per CLAUDE.md
+# hard stop ("Never commit *.env"). Exemptions above (.env.example etc.) run
+# first.
+if echo "$path" | grep -qE '\.env$|\.pem$|(^|/)credentials\.|(^|/)secrets?(\.|$)|(^|/)token(\.|$)|\.gpg$|id_rsa$|id_ed25519$'; then
+  echo "BLOCKED (secret_path_guard): $path matches secret-bearing pattern. If intentional, rename to *.example or *.template variant." >&2
   exit 2
 fi
 

--- a/scripts/instructions_on_start.sh
+++ b/scripts/instructions_on_start.sh
@@ -20,19 +20,7 @@ if [[ "$_remote_url" =~ ^http://(.+@)?127\.0\.0\.1:([0-9]+)/ ]]; then
     if [ -n "${GITHUB_TOKEN:-}" ]; then
       git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/domattioli/CHILmesh.git"
       echo "⚠ Local git proxy dead on :$_port — switched origin to github.com via GITHUB_TOKEN"
-      # Resync local with remote (covers case where prior session pushed via MCP)
-      if git fetch origin daily-maintenance 2>/dev/null; then
-        _local_sha=$(git rev-parse HEAD 2>/dev/null || echo "")
-        _remote_sha=$(git rev-parse origin/daily-maintenance 2>/dev/null || echo "")
-        if [ -n "$_local_sha" ] && [ -n "$_remote_sha" ] && [ "$_local_sha" != "$_remote_sha" ]; then
-          if [ -z "$(git status --porcelain 2>/dev/null)" ]; then
-            git reset --hard origin/daily-maintenance >/dev/null
-            echo "  ↳ Resynced HEAD: $_local_sha → $_remote_sha"
-          else
-            echo "  ↳ Dirty tree; not resyncing. Local=$_local_sha Remote=$_remote_sha"
-          fi
-        fi
-      fi
+      echo "⚠ proxy dead — manual recovery: git fetch origin development && git status"
     else
       echo "⚠ Local git proxy dead on :$_port and no GITHUB_TOKEN — push will fail" >&2
     fi


### PR DESCRIPTION
Recreates the policy-mandated `development` staging branch (was deleted at #195 merge; CLAUDE.md mandates it) and lands three fixes from the 2026-06-12 ecosystem audit (DomI#265):

- `8f6747a` — `secret_path_guard.sh`: regex synced to DomI canon. Previous copy let `/repo/.env` and root-relative `credentials.json` writes through (verified by execution before/after; now exit 2 = blocked).
- `f684c99` — `instructions_on_start.sh`: removed destructive `git reset --hard origin/daily-maintenance` on dead-proxy detection (deprecated branch, DomI #196) — replaced with a non-destructive warning.
- `c9f0e6c` — MANIFEST.in: exclude Claude-derived docs from distributions (operator directive 2026-06-12).

Note for reviewers: CI (`python-package.yml`) does not currently run on `development` pushes — PR-mode lane covers this PR. Adding a development lane is tracked in DomI#265.

https://claude.ai/code/session_01RqYaYzJ1MaWGAzscnyKAeP

---
_Generated by [Claude Code](https://claude.ai/code/session_01RqYaYzJ1MaWGAzscnyKAeP)_