### PR TITLE
test: add spatial-indexing edge cases (suite otherwise confirmed healthy)

### DIFF
--- a/tests/test_spatial_indexing.py
+++ b/tests/test_spatial_indexing.py
@@ -2,6 +2,7 @@
 import pytest
 import numpy as np
 from chilmesh.examples import annulus, donut
+from chilmesh import examples as _examples
 
 
 class TestSpatialIndexing:
@@ -86,6 +87,83 @@ class TestSpatialIndexing:
         centroids = mesh.centroids
         assert centroids.shape == (mesh.n_elems, 2)
         assert np.all(np.isfinite(centroids))
+
+
+class TestSpatialIndexingEdgeCases:
+    """Edge-case tests for spatial indexing (boundary, zero, negative inputs)."""
+
+    def test_nearest_vertices_k_zero(self, mesh):
+        """nearest_vertices with k=0 should return empty array."""
+        point = mesh.points[0, :2]
+        result = mesh.nearest_vertices(point, k=0)
+        assert isinstance(result, np.ndarray)
+        assert len(result) == 0
+        assert result.dtype == int
+
+    def test_nearest_elements_k_zero(self, mesh):
+        """nearest_elements with k=0 should return empty array."""
+        point = mesh.points[0, :2]
+        result = mesh.nearest_elements(point, k=0)
+        assert isinstance(result, np.ndarray)
+        assert len(result) == 0
+        assert result.dtype == int
+
+    def test_nearest_vertices_coincident_with_vertex(self, mesh):
+        """Query point at exact vertex should have distance 0 to first nearest."""
+        v_id = min(5, mesh.n_verts - 1)
+        point = mesh.points[v_id, :2].copy()
+        nearest = mesh.nearest_vertices(point, k=1)
+        assert nearest[0] == v_id
+        # Verify distance is truly zero
+        dist = np.linalg.norm(mesh.points[nearest[0], :2] - point)
+        assert dist < 1e-10
+
+    def test_find_elements_in_radius_zero(self, mesh):
+        """find_elements_in_radius with radius=0 should only return elements at point."""
+        if mesh.grid_name in ['annulus', 'donut']:
+            pytest.skip("Mesh has hole; center may be outside domain")
+        centroid = np.mean(mesh.points[:, :2], axis=0)
+        elems_zero = mesh.find_elements_in_radius(centroid, radius=0.0)
+        elems_small = mesh.find_elements_in_radius(centroid, radius=0.01)
+        # Zero radius should return at most as many as small radius
+        assert len(elems_zero) <= len(elems_small)
+        # Both should be finite lists
+        assert isinstance(elems_zero, np.ndarray)
+        assert isinstance(elems_small, np.ndarray)
+
+    def test_find_elements_in_radius_negative_raises_value_error(self, mesh):
+        """find_elements_in_radius with negative radius should raise ValueError."""
+        point = mesh.points[0, :2]
+        with pytest.raises(ValueError, match="radius must be >= 0"):
+            mesh.find_elements_in_radius(point, radius=-0.1)
+
+    def test_find_element_inside_mixed_element_mesh(self):
+        """find_element should work on mixed tri/quad mesh."""
+        mesh = _examples.structured()
+        # All vertices should have elements
+        for v_id in range(min(10, mesh.n_verts)):
+            point = mesh.points[v_id, :2]
+            elem_id = mesh.find_element(point)
+            assert elem_id >= 0, f"Failed to find element for vertex {v_id} on structured mesh"
+            assert v_id in mesh.connectivity_list[elem_id]
+
+    def test_nearest_vertices_k_exceeds_mesh_size(self, mesh):
+        """Requesting k > mesh.n_verts should clamp to n_verts."""
+        point = mesh.points[0, :2]
+        requested_k = mesh.n_verts + 100
+        result = mesh.nearest_vertices(point, k=requested_k)
+        # Should return exactly n_verts, not more
+        assert len(result) == mesh.n_verts
+        assert len(result) < requested_k
+
+    def test_nearest_elements_k_exceeds_mesh_size(self, mesh):
+        """Requesting k > mesh.n_elems should clamp to n_elems."""
+        point = mesh.points[0, :2]
+        requested_k = mesh.n_elems + 100
+        result = mesh.nearest_elements(point, k=requested_k)
+        # Should return exactly n_elems, not more
+        assert len(result) == mesh.n_elems
+        assert len(result) < requested_k
 
 
 class TestSpatialIndexingPerformance:


### PR DESCRIPTION
Phase 2 of the test-suite right-sizing (audit: #244). The suite is already in excellent shape (1333 pass, no dup/dead tests, block_o already cache-optimized) — so this is a small, targeted EXPAND on the one thin-coverage module, nothing else.

- **Change** (test-only)
    ▸ `test_spatial_indexing.py`
        ↪ +8 edge-case methods (×~5 fixtures = +34 tests): `nearest_vertices`/`nearest_elements` with k=0 and k>n (clamping), coincident-point distance-0, `find_elements_in_radius` radius=0 monotonicity + negative-radius `ValueError`, `find_element` on a mixed tri/quad mesh.

- **Result**
    ▸ Tests
        ↪ 54 → 88 passing in this file, 0 failed. Source untouched. Mutation-verified: removing the negative-radius validation makes `test_..._negative_radius_raises_value_error` fail (all fixtures) → the test genuinely catches the defect.

- **Note: audit confirmed the suite is healthy**
    ↪ the block_o redundancy I set out to cut is already solved via `_MESH_CACHE` (CLAUDE.md's ~30s number is stale, actual ~0.3s); no duplicate/dead tests; `backend_equivalence` contract untouched.

- **Deferred (in #244)**
    a. Docs refresh: CLAUDE.md "Known Limitations" still lists spatial-indexing + mutation-ops as open (both shipped); block_o "~30s" + "36-case" backend-equivalence numbers stale.

    b. Extend incremental-mutation tests beyond `annulus` to `structured`/`donut` — deliberately (may surface real mixed-element edge cases), not a blind parametrize.

- **Branch note**
    ↪ CHILmesh policy is `development`-only; this landed on the session's harness branch `claude/test-review-prompt-1rx6nb`. Retarget/rebase to `development` as the repo prefers.

Addresses the Phase-2 portion of #244.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015AxGTXF6qKsUCDyuxJVH2L)_